### PR TITLE
fix(aina): escape angle-bracket placeholders in Max Insights BRD (MDX build)

### DIFF
--- a/docs/product/merchant/aina/max_insights_scheduled_alerts_brd.md
+++ b/docs/product/merchant/aina/max_insights_scheduled_alerts_brd.md
@@ -269,7 +269,7 @@ A merchant can only ever list and delete their own store's scheduled alerts.
 
 ### Happy Path
 
-- Create a daily orders+leads alert at 9:00 AM in chat → confirmation appears → it later shows on the Scheduled Alerts page reading "Daily at 9:00 AM (<tz>)" with scope "Orders, Leads · <period>" and an ENABLED badge.
+- Create a daily orders+leads alert at 9:00 AM in chat → confirmation appears → it later shows on the Scheduled Alerts page reading "Daily at 9:00 AM (`<tz>`)" with scope "Orders, Leads · `<period>`" and an ENABLED badge.
 - Create a one-time alert 5 minutes out → at fire time a bell row and an email arrive with a real-data summary → the alert later shows as DISABLED on the page.
 - Open Settings → Scheduled Alerts, click Delete on an alert, confirm → the row disappears and the alert no longer fires.
 


### PR DESCRIPTION
@
## What

Fixes the failing Docusaurus build on `dev` caused by PR #186.

MDX parsed the placeholders `<tz>` and `<period>` in the Max Insights Scheduled Alerts BRD as unclosed JSX tags, failing the build:

> Expected a closing tag for `<period>` ... MDX compilation failed

This wraps both placeholders in inline code so MDX treats them as literal text.

## Verification

`npm run build` passes locally (only the pre-existing unrelated `login.js` warning remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@